### PR TITLE
Added label comment to make matching animation to frames easier

### DIFF
--- a/templates/easeljs.template
+++ b/templates/easeljs.template
@@ -2,7 +2,7 @@
 	"images": ["{{name}}.png"],
 	"frames": [
 		{{#files}}
-	        [{{x}}, {{y}}, {{width}}, {{height}}]{{^isLast}},{{/isLast}}
+	        [{{x}}, {{y}}, {{width}}, {{height}}]{{^isLast}},{{/isLast}}// {{name}}
 	    {{/files}}
 	],
 	"animations": {


### PR DESCRIPTION
To save time when working with large spritesheets, makes it easier to match the frame to its corresponding animation declaration.
