### PR TITLE
Fix file paths issue on trim operation.

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var Mustache = require('mustache');
 var async = require('async');
 var os = require('os');
+var path = require('path');
 
 var packing = require('./packing/packing.js');
 /**
@@ -19,10 +20,10 @@ exports.trimImages = function (files, options, callback) {
 	async.eachSeries(files, function (file, next) {
 		file.originalPath = file.path;
 		i++;
-		file.path = os.tmpDir() + 'image_' +i;
+		file.path = path.join(os.tmpDir(), 'image_' + i);
 
 		//have to add 1px transparent border because imagemagick do trimming based on border pixel's color
-		exec('convert -define png:exclude-chunks=date ' + file.originalPath + ' -bordercolor transparent -border 1 -trim ' + file.path, next);
+		exec('convert -define png:exclude-chunks=date "' + file.originalPath + '" -bordercolor transparent -border 1 -trim "' + file.path + '"', next);
 	}, callback);
 };
 


### PR DESCRIPTION
Hi.

This one fixes two little issues I found using spritesheet-js `--trim` option.

Firstly, file paths weren't quoted, causing errors in ImageMagick's `convert` when directories included spaces in names. The other problem was that the temporary file couldn't be generated because of a wrong path.
