### PR TITLE
Fix width/height for trimmed images

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -20,7 +20,7 @@ exports.trimImages = function (files, options, callback) {
 	async.eachSeries(files, function (file, next) {
 		file.originalPath = file.path;
 		i++;
-		file.path = path.join(os.tmpDir(), 'image_' + i);
+		file.path = path.join(os.tmpDir(), 'image_' + i + '.png');
 
 		//have to add 1px transparent border because imagemagick do trimming based on border pixel's color
 		exec('convert -define png:exclude-chunks=date "' + file.originalPath + '" -bordercolor transparent -border 1 -trim "' + file.path + '"', next);
@@ -54,8 +54,8 @@ exports.getImagesSizes = function (files, options, callback) {
 				files[i].trim = {};
 				files[i].trim.x = parseInt(rect[3], 10) - 1;
 				files[i].trim.y = parseInt(rect[4], 10) - 1;
-				files[i].trim.width = parseInt(rect[1], 10) ;
-				files[i].trim.height = parseInt(rect[2], 10);
+				files[i].trim.width = parseInt(rect[1], 10) - 2;
+				files[i].trim.height = parseInt(rect[2], 10) - 2;
 
 				files[i].trimmed = (files[i].trim.width !== files[i].width - options.padding * 2 || files[i].trim.height !== files[i].height - options.padding * 2);
 			}


### PR DESCRIPTION
The width and height reported by `identify` for trimmed PNG images is incorrect because the transparent border added by trimImages is included in the new page size and offset. For example, for a 32x32 trimmed image, `identify` reports a geometry of 34x34+1+1. Also, because PNG images support canvas metadata but other formats may not (JPEG), the trimmed file is always explicitly converted to PNG so that the new calculation always works correctly.
