### PR TITLE
Fix vertical algorithm bug - maxWidth is now correct

### DIFF
--- a/lib/packing/packing.js
+++ b/lib/packing/packing.js
@@ -76,7 +76,7 @@ function vertical(files, options) {
   files.forEach(function (item) {
     item.x = 0;
     item.y = y;
-    maxWidth = Math.max(maxWidth, item.height);
+    maxWidth = Math.max(maxWidth, item.width);
     y += item.height;
   });
 


### PR DESCRIPTION
The vertical algorithm was not calculating the correct maxWidth resulting in the sprite being with shorter width than needed.