### PR TITLE
bug with divisibleByTwo option when trimmed offset was equal to 1 and…

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -51,12 +51,15 @@ exports.getImagesSizes = function (files, options, callback) {
 			var size = item.match(/ ([0-9]+)x([0-9]+) /);
 			files[i].width = parseInt(size[1], 10) + options.padding * 2;
 			files[i].height = parseInt(size[2], 10) + options.padding * 2;
+			var forceTrimmed = false;
 			if (options.divisibleByTwo) {
 				if (files[i].width & 1) {
 					files[i].width += 1;
+					forceTrimmed = true;
 				}
 				if (files[i].height & 1) {
 					files[i].height += 1;
+					forceTrimmed = true;
 				}
 			}
 			files[i].area = files[i].width * files[i].height;
@@ -70,23 +73,7 @@ exports.getImagesSizes = function (files, options, callback) {
 				files[i].trim.width = parseInt(rect[1], 10) - 2;
 				files[i].trim.height = parseInt(rect[2], 10) - 2;
 
-				if (options.divisibleByTwo) {
-					if (files[i].trim.x & 1) {
-						files[i].trim.x -= 1;
-						files[i].trim.width -= 2;
-					}
-					if (files[i].trim.y & 1) {
-						files[i].trim.y -= 1;
-						files[i].trim.height -= 2;
-					}
-					if (files[i].trim.width & 1) {
-						files[i].trim.width += 1;
-					}
-					if (files[i].trim.height & 1) {
-						files[i].trim.height += 1;
-					}
-				}
-				files[i].trimmed = (files[i].trim.width !== files[i].width - options.padding * 2 || files[i].trim.height !== files[i].height - options.padding * 2);
+				files[i].trimmed = forceTrimmed || (files[i].trim.width !== files[i].width - options.padding * 2 || files[i].trim.height !== files[i].height - options.padding * 2);
 			}
 		});
 		callback(null, files);


### PR DESCRIPTION
… width of trimmed area was equal to image width - 1 fixed