### PR TITLE
Remove comments on EaselJS template

### DIFF
--- a/templates/easeljs.template
+++ b/templates/easeljs.template
@@ -2,7 +2,7 @@
 	"images": ["{{{name}}}.png"],
 	"frames": [
 		{{#files}}
-			[{{x}}, {{y}}, {{width}}, {{height}}]{{^isLast}},{{/isLast}} //{{{name}}}
+			[{{x}}, {{y}}, {{width}}, {{height}}]{{^isLast}},{{/isLast}}
 		{{/files}}
 	],
 	"animations": {


### PR DESCRIPTION
Having comments lead to parse error. JSON **does not support** comments.

[More info](http://stackoverflow.com/questions/244777/can-comments-be-used-in-json)