### PR TITLE
dependence update fixed

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,4 +1,4 @@
-var exec = require('platform-command').exec;
+var exec = require('platform-cmd').exec;
 var fs = require('fs');
 var Mustache = require('mustache');
 var async = require('async');


### PR DESCRIPTION
require('platform-command') => require('platform-cmd')

to fix `Error: Cannot find module 'platform-command'` in 1.2.0