### PR TITLE
Remove css specific prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ if (!module.parent) {
  * @param {string} options.customFormat external format template
  * @param {string} options.name name of the generated spritesheet
  * @param {string} options.path path to the generated spritesheet
- * @param {string} options.prefix prefix for image paths (css format only)
+ * @param {string} options.prefix prefix for image paths
  * @param {boolean} options.fullpath include path in file name
  * @param {boolean} options.trim removes transparent whitespaces around images
  * @param {boolean} options.square texture should be square

--- a/templates/css.template
+++ b/templates/css.template
@@ -2,7 +2,7 @@
 .{{{cssName}}} {
     width: {{width}}px;
     height: {{height}}px;
-    background: url("{{{prefix}}}{{{spritesheetName}}}.png") -{{x}}px -{{y}}px;
+    background: url("{{{spritesheetName}}}.png") -{{x}}px -{{y}}px;
 }
 
 {{/files}}


### PR DESCRIPTION
I have tried to use prefix param in css and I have observed that the prefix is used both in frame names and spritesheet path.

```
.prefix-pine {
    width: 80px;
    height: 112px;
    background: url("prefix-objects.png") -0px -0px;
}

.prefix-house {
    width: 80px;
    height: 96px;
    background: url("prefix-objects.png") -160px -0px;
}

```

Commit 7007f571d19a1fd6117b4b2397798aed55a98b1d introduces css format support with a specific for this format prefix param for a spritesheet path.
Commit 1d37924c66bc4b83a7e9aff6b9733298192d7c15 makes use of exactly same param but in completely different way. It must have broken use of the css specific prefix but as it was before 1.0 release I guess it was not a big deal.

I think that because these prefixes have different usecases they should have different names like _framePrefix_ and _cssPrefix_. One of the prefixes could stick to the old name so breaking changes would be minimised.

However two different prefixed would complicate API. And as I fail to find any usecase for the css specific prefix, **I propose just to remove css specific prefix** (Why this format is treated different way?). **The prefix would be used only in fame names then**. That make api a bit more intuitive and fix the buggy behaviour.

I'm aware that it's a breaking change but it has been already broken once and is not useful in current form anyway, so I would be pragmatic about it.
