### PR TITLE
Fix scaling without trimming

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function generate(files, options, callback) {
 
   async.waterfall([
     function (callback) {
-      generator.trimImages(files, options, callback);
+      generator.prepareImages(files, options, callback);
     },
     function (callback) {
       generator.getImagesSizes(files, options, callback);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -10,15 +10,21 @@ var packing = require('./packing/packing.js');
 var sorter = require('./sorter/sorter.js');
 
 /**
- * Generate temporary trimmed image files
+ * Generate temporary transformed image files
  * @param {string[]} files
  * @param {object} options
  * @param {boolean} options.trim is trimming enabled
+ * @param {boolean} options.fuzz is fuzzing enabled
+ * @param {boolean} options.scale is scaling enabled
  * @param callback
  */
-exports.trimImages = function (files, options, callback) {
-	if (!options.trim) return callback(null);
-	
+exports.prepareImages = function (files, options, callback) {
+	var scale = options.scale && (options.scale !== '100%') ? ' -resize ' + options.scale : '';
+	var fuzz = options.fuzz ? ' -fuzz ' + options.fuzz : '';
+	//have to add 1px transparent border because imagemagick does trimming based on border pixel's color
+	var trim = options.trim ? ' -bordercolor transparent -border 1 -trim' : '';
+	if ((scale + fuzz + trim).length == 0) return callback(null)
+
 	var uuid = crypto.randomBytes(16).toString("hex");
 	var i = 0;
 	async.eachSeries(files, function (file, next) {
@@ -26,10 +32,7 @@ exports.trimImages = function (files, options, callback) {
 		i++;
 		file.path = path.join(os.tmpDir(), 'spritesheet_js_' + uuid + "_" + (new Date()).getTime() + '_image_' + i + '.png');
 
-		var scale = options.scale && (options.scale !== '100%') ? ' -resize ' + options.scale : '';
-		var fuzz = options.fuzz ? ' -fuzz ' + options.fuzz : '';
-		//have to add 1px transparent border because imagemagick does trimming based on border pixel's color
-		exec('convert' + scale + ' ' + fuzz + ' -define png:exclude-chunks=date "' + file.originalPath + '" -bordercolor transparent -border 1 -trim "' + file.path + '"', next);
+		exec('convert' + scale + ' ' + fuzz + ' -define png:exclude-chunks=date "' + file.originalPath + '" ' + trim + ' "' + file.path + '"', next);
 	}, callback);
 };
 


### PR DESCRIPTION
Currently it is not possible to use scale without the trim option.

This PR fixes that.

BTW, The mocha tests failed locally (before starting the PR) on the `determineCanvasSize` method