### PR TITLE
fix mis-ordering for non-CSS formats. #47

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -18,7 +18,7 @@ var sorter = require('./sorter/sorter.js');
  */
 exports.trimImages = function (files, options, callback) {
 	if (!options.trim) return callback(null);
-	
+
 	var uuid = crypto.randomBytes(16).toString("hex");
 	var i = 0;
 	async.eachSeries(files, function (file, next) {
@@ -217,9 +217,11 @@ exports.generateData = function (files, options, callback) {
 			});
 		}
 
-		options.files.sort(function(a, b) {
-			return a.cssPriority - b.cssPriority;
-		});
+		if (options.format === "css") {
+			options.files.sort(function(a, b) {
+				return a.cssPriority - b.cssPriority;
+			});
+		}
 
 		options.files[options.files.length - 1].isLast = true;
 


### PR DESCRIPTION
Fix ordering issue when using a different format than CSS. 

When having a file named  `"_hover"` or `"_active"`, they used to have its order changed, which breaks the JSON format for CreateJS, for example.

Possibly related to issue: https://github.com/krzysztof-o/spritesheet.js/issues/47