### PR TITLE
Remove the platform-command package

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,4 +1,4 @@
-var exec = require('platform-command').exec;
+var exec = require('child_process').exec;
 var fs = require('fs');
 var Mustache = require('mustache');
 var async = require('async');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "glob": "~3.2.6",
     "mustache": "~0.7.2",
     "optimist": "~0.6.0",
-    "platform-command": "git+https://gitlab.com/gitlabdev/platform-command.git",
     "underscore": "1.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I removed the legacy package "platform-command". Because of this package, the script did not work in cmd and powershell on Windows.