### PR TITLE
Stable output binary and external algorithm option

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -33,7 +33,7 @@ exports.trimImages = function (files, options, callback) {
 		var scale = options.scale && (options.scale !== '100%') ? ' -resize ' + options.scale : '';
 		var fuzz = options.fuzz ? ' -fuzz ' + options.fuzz : '';
 		//have to add 1px transparent border because imagemagick does trimming based on border pixel's color
-		exec('convert' + scale + ' ' + fuzz + ' -define png:exclude-chunks=date "' + file.originalPath + '" -bordercolor transparent -border 1 -trim "' + file.path + '"', next);
+		exec('convert' + scale + ' ' + fuzz + ' -define png:exclude-chunks=date,time "' + file.originalPath + '" -bordercolor transparent -border 1 -trim "' + file.path + '"', next);
 	}, callback);
 };
 
@@ -120,7 +120,7 @@ exports.determineCanvasSize = function (files, options, callback) {
 
 function makeCommands(fileList, options, index) {
 	return [
-		`convert -define png:exclude-chunks=date -quality 0% -size ${options.width}x${options.height} xc:none`,
+		`convert -define png:exclude-chunks=date,time -quality 0% -size ${options.width}x${options.height} xc:none`,
 		index !== 0 &&
 			`"${options.path}/${options.name}.png" -composite`,
 		...fileList.map(

--- a/lib/packing/packing.js
+++ b/lib/packing/packing.js
@@ -8,7 +8,11 @@ var algorithms = {
 };
 exports.pack = function (algorithm, files, options) {
   algorithm = algorithm || 'growing-binpacking';
-  algorithms[algorithm](files, options);
+  if(typeof algorithm === 'function') {
+    algorithm(files, options);
+  } else {
+    algorithms[algorithm](files, options);
+  }
 
   if (options.validate) {
     validate(files, options);


### PR DESCRIPTION
1. Let user provide a function by options.algorithm to override the pack methods.
(previously only built-in methods are used)

2. Remove the time chunk to generate stable binary atlas output.
(previously only date is removed, but there is also a time stamp generated by ImageMagick)