### PR TITLE
Add support for SVG with transparent background

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -120,7 +120,7 @@ exports.determineCanvasSize = function (files, options, callback) {
 
 function makeCommands(fileList, options, index) {
 	return [
-		`convert -define png:exclude-chunks=date -quality 0% -size ${options.width}x${options.height} xc:none -set comment "Created with spritesheet.js"`,
+		`convert -define png:exclude-chunks=date -quality 0% -size ${options.width}x${options.height} xc:none -set comment "Created with spritesheet.js" -background none`,
 		index !== 0 &&
 			`"${options.path}/${options.name}.png" -composite`,
 		...fileList.map(


### PR DESCRIPTION
The default ImageMagick background is white. This isn't a problem for PNGs, but when it rasterizes SVGs, it will pick white as the instead of transparent.

For your convenience testing this change, here is an SVG :slightly_smiling_face: 
![adamant](https://github.com/krzysztof-o/spritesheet.js/assets/6908397/bcf1f9cd-d659-44e5-9994-a742015afb9b)
