### PR TITLE
Fix incorrect globs in Windows OS terminals (cmd, powershell)

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,8 @@ if (!module.parent) {
  * @param {function} callback
  */
 function generate(files, options, callback) {
-  files = Array.isArray(files) ? files : glob.sync(files);
+  var isProvidedPattern = !Array.isArray(files) || files.length === 1;
+  files = isProvidedPattern ? glob.sync(files[0] || files) : files;
   if (files.length == 0) return callback(new Error('no files specified'));
 
   options = options || {};


### PR DESCRIPTION
NodeJS automatically parses globs in `argv`, but the actual algorithm depends on shell.
Consider following example:
```
node .\index.js ..\..\Graphics\*.png
```
In WSL it will lead to `files` containing following
```
[ '../../Graphics/Button.png',
  '../../Graphics/ButtonCulprit.png',
  '../../Graphics/ButtonCulprit_selected.png',
  '../../Graphics/ButtonWide.png',
  '../../Graphics/ButtonWide_selected.png',   
  '../../Graphics/Button_selected.png',
  '../../Graphics/LabelSelectCulprit.png',
  '../../Graphics/Login.png',
  '../../Graphics/Modal.png' ]
```
While both in powershell and cmd `files` will contain
```
[ '..\\..\\Graphics\\*.png' ]
```
See https://github.com/nodejs/node/issues/15529

Current logic inside `generate` function tries parsing glob only if it's not array (in reality it's array that contains single element)