### PR TITLE
Replace exec with execSync

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,4 +1,15 @@
-var exec = require('platform-command').exec;
+const { execSync } = require('child_process');
+
+const exec = function (cmd, callback) {
+  let stdoutBuffer = '', err = '';
+  try {
+    stdoutBuffer = execSync(cmd);
+  } catch (e) {
+    err = e.toString();
+  }
+  callback(err, stdoutBuffer.toString());
+}
+
 var fs = require('fs');
 var Mustache = require('mustache');
 var async = require('async');


### PR DESCRIPTION
To solve the problem that "exec" from "platform-command" fails with error code 127 even with ImageMagick installed.

no sure if it occurs on a different environment, mine is windows 11 with nodejs 20.11.1